### PR TITLE
Hotfix/jdk fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'temurin'
+        java-version: '17'
+        distribution: 'corretto'
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>SLM_Projekt_Monitor</name>
     <description>SLM_Projekt_Monitor</description>
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Der Fehler beim Ausführen hat darauf hingewiesen, dass (keine Ahnung warum) die betroffene Klasse mit Java 11 nicht kompatibel war, welche ihr in der Build Action referenziert habt. Ich habe jetzt die die Projekt Version, sowie die Version in der Github Action auf 17 umgestellt. Bitte gerne den Pull Request prüfen, akzeptieren und schauen ob der Build/die Action dann durchgeht.

Ihr werdet die SDK 17 auch zu eurem Projekt Lokal hinzufügen müssen. Die notwendigen Schritte haben wir in der 3ten Einheit gemacht, bzw. ist es auch in der Doku vom Referenzprojekt erklärt.